### PR TITLE
Feat: adminer 연결#18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,5 +36,11 @@ services:
       - db
     ports:
       - 3000:3000
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080
     #env_file:
     #  - ./api/.env.stage.dev


### PR DESCRIPTION
## 기능에 대한 설명

BE, FE에서 App 테스트시 유연한 data 테스트를 위해 adminer를 설치했습니다.

## 테스트 (Optional)

docker-compose up --build 후, localhost:8080으로 연결 확인

## REFERENCE (Optional)

[Adminer 설치 메뉴얼](https://hub.docker.com/_/adminer)

## ISSUE

close #18
