### PR TITLE
fix: submodules가 최신으로 업데이트 되도록 수정(#12)

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,0 +1,30 @@
+# Reference
+# https://stackoverflow.com/questions/64407333/using-github-actions-to-automatically-update-the-repos-submodules
+
+name: Update submodule
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+
+      - name: Commit
+        run: |
+          git config --global user.name 'ykoh42'
+          git config --global user.email 'kohyounghwan@gmail.com'
+          git add .
+          git commit -m "Update: submodules" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
> ⚠️ 이슈 없이 Pull Request 금지  
> 아래 항목은 필수이지만, 필요없다고 생각하는 부분은 삭제하고 필요한 부분은 자유롭게 추가 가능

## 기능에 대한 설명
예전에 멘토링 받았을 때, 멘토님이 트렌센던스 레파지토리 들어가셨던적있는데 백엔드 폴더들어가셨다가 왜이리 모듈이 적냐 하셨던 적이 있었습니다. 이게 서브모듈이 최신으로 업데이트 되지않아서 업데이트 되지않았던 커밋으로 가져서 그런 건데 이런 문제 때문에 꼭 수정하고 싶었어요.

GitHub Actions를 통해 하루에 한번 업데이트 후 푸시하도록 작성하였습니다.

## 테스트 (Optional)
테스트는 진행하지 못했어요..

## REFERENCE (Optional)
https://stackoverflow.com/questions/64407333/using-github-actions-to-automatically-update-the-repos-submodules

## ISSUE
close #12
